### PR TITLE
Fixed bug showing 0.15 instead of 15.00

### DIFF
--- a/SCRIPTS/TELEMETRY/LuaPilot.lua
+++ b/SCRIPTS/TELEMETRY/LuaPilot.lua
@@ -545,7 +545,7 @@ end
    if (HVlipoDetected == 1 and data.battsum >=10) then
      lcd.drawNumber(0,57, data.battsum,PREC1+ LEFT )
    else
-     lcd.drawNumber(0,57, data.battsum,PREC2 + LEFT )
+     lcd.drawNumber(0,57, data.battsum*100,PREC2 + LEFT )
    end
 
 


### PR DESCRIPTION
VFAS is reported as 15.00 so using lua PREC2 flag we should multiply it by 100 to save 2 decimal places precision.
